### PR TITLE
fix(optimizer): rebase: browser field bare import

### DIFF
--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -168,35 +168,35 @@ export function esbuildDepPlugin(
         }
       }
 
-      build.onResolve(
-        { filter: /^[\w@][^:]/ },
-        async ({ path: id, importer, kind }) => {
-          if (moduleListContains(external, id)) {
-            return {
-              path: id,
-              external: true
-            }
-          }
-
-          // ensure esbuild uses our resolved entries
-          let entry: { path: string; namespace: string } | undefined
-          // if this is an entry, return entry namespace resolve result
-          if (!importer) {
-            if ((entry = resolveEntry(id))) return entry
-            // check if this is aliased to an entry - also return entry namespace
-            const aliased = await _resolve(id, undefined, true)
-            if (aliased && (entry = resolveEntry(aliased))) {
-              return entry
-            }
-          }
-
-          // use vite's own resolver
-          const resolved = await resolve(id, importer, kind)
-          if (resolved) {
-            return resolveResult(id, resolved)
+      build.onResolve({ filter: /./ }, async ({ path: id, importer, kind }) => {
+        if (
+          /^[\w@][^:]/.test(id) &&
+          moduleListContains(external, id)
+        ) {
+          return {
+            path: id,
+            external: true
           }
         }
-      )
+
+        // ensure esbuild uses our resolved entries
+        let entry: { path: string; namespace: string } | undefined
+        // if this is an entry, return entry namespace resolve result
+        if (!importer) {
+          if ((entry = resolveEntry(id))) return entry
+          // check if this is aliased to an entry - also return entry namespace
+          const aliased = await _resolve(id, undefined, true)
+          if (aliased && (entry = resolveEntry(aliased))) {
+            return entry
+          }
+        }
+
+        // use vite's own resolver
+        const resolved = await resolve(id, importer, kind)
+        if (resolved) {
+          return resolveResult(id, resolved)
+        }
+      })
 
       // For entry files, we'll read it ourselves and construct a proxy module
       // to retain the entry's raw id instead of file path so that esbuild

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -169,10 +169,7 @@ export function esbuildDepPlugin(
       }
 
       build.onResolve({ filter: /./ }, async ({ path: id, importer, kind }) => {
-        if (
-          /^[\w@][^:]/.test(id) &&
-          moduleListContains(external, id)
-        ) {
+        if (/^[\w@][^:]/.test(id) && moduleListContains(external, id)) {
           return {
             path: id,
             external: true

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -75,13 +75,13 @@ export function esbuildDepPlugin(
     // explicit resolveDir - this is passed only during yarn pnp resolve for
     // entries
     if (resolveDir) {
-      _importer = normalizePath(path.join(resolveDir, '*'))
+      _importer = path.join(resolveDir, '*')
     } else {
       // map importer ids to file paths for correct resolution
       _importer = importer in qualified ? qualified[importer] : importer
     }
     const resolver = kind.startsWith('require') ? _resolveRequire : _resolve
-    return resolver(id, _importer, undefined, ssr)
+    return resolver(id, normalizePath(_importer), undefined, ssr)
   }
 
   const resolveResult = (id: string, resolved: string) => {

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -58,6 +58,10 @@ test('cjs browser field (axios)', async () => {
   expect(await page.textContent('.cjs-browser-field')).toBe('pong')
 })
 
+test('cjs browser field bare', async () => {
+  expect(await page.textContent('.cjs-browser-field-bare')).toBe('pong')
+})
+
 test('dep from linked dep (lodash-es)', async () => {
   expect(await page.textContent('.deps-linked')).toBe('fooBarBaz')
 })

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/events-shim.js
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/events-shim.js
@@ -1,0 +1,3 @@
+module.exports = {
+  foo: 'foo'
+}

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/index.js
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const internal = require('./internal')
+
+module.exports = internal

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/internal.js
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/internal.js
@@ -1,5 +1,6 @@
 'use strict'
 
+// eslint-disable-next-line import/no-nodejs-modules
 const events = require('events')
 
 module.exports = 'foo' in events ? 'pong' : ''

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/internal.js
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/internal.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const events = require('events')
+
+module.exports = 'foo' in events ? 'pong' : ''

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/package.json
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dep-cjs-browser-field-bare",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "browser": {
+    "events": "./events-shim.js"
+  }
+}

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -29,6 +29,9 @@
 <h2>CommonJS w/ browser field mapping (axios)</h2>
 <div>This should show pong: <span class="cjs-browser-field"></span></div>
 
+<h2>CommonJS w/ bare id browser field mapping</h2>
+<div>This should show pong: <span class="cjs-browser-field-bare"></span></div>
+
 <h2>Detecting linked src package and optimizing its deps (lodash-es)</h2>
 <div>This should show fooBarBaz: <span class="deps-linked"></span></div>
 
@@ -99,6 +102,9 @@
 <script type="module">
   // test dep detection in globbed files
   const globbed = import.meta.glob('./glob/*.js', { eager: true })
+
+  import cjsBrowerFieldBare from 'dep-cjs-browser-field-bare'
+  text('.cjs-browser-field-bare', cjsBrowerFieldBare)
 
   import { camelCase } from 'dep-linked'
   text('.deps-linked', camelCase('foo-bar-baz'))

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "clipboard": "^2.0.11",
+    "dep-cjs-browser-field-bare": "file:./dep-cjs-browser-field-bare",
     "dep-cjs-compiled-from-cjs": "file:./dep-cjs-compiled-from-cjs",
     "dep-cjs-compiled-from-esm": "file:./dep-cjs-compiled-from-esm",
     "dep-cjs-with-assets": "file:./dep-cjs-with-assets",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -631,6 +631,7 @@ importers:
       added-in-entries: file:./added-in-entries
       axios: ^0.27.2
       clipboard: ^2.0.11
+      dep-cjs-browser-field-bare: file:./dep-cjs-browser-field-bare
       dep-cjs-compiled-from-cjs: file:./dep-cjs-compiled-from-cjs
       dep-cjs-compiled-from-esm: file:./dep-cjs-compiled-from-esm
       dep-cjs-with-assets: file:./dep-cjs-with-assets
@@ -660,6 +661,7 @@ importers:
       added-in-entries: file:playground/optimize-deps/added-in-entries
       axios: 0.27.2
       clipboard: 2.0.11
+      dep-cjs-browser-field-bare: file:playground/optimize-deps/dep-cjs-browser-field-bare
       dep-cjs-compiled-from-cjs: file:playground/optimize-deps/dep-cjs-compiled-from-cjs
       dep-cjs-compiled-from-esm: file:playground/optimize-deps/dep-cjs-compiled-from-esm
       dep-cjs-with-assets: file:playground/optimize-deps/dep-cjs-with-assets
@@ -689,6 +691,9 @@ importers:
       '@vitejs/plugin-vue': link:../../packages/plugin-vue
 
   playground/optimize-deps/added-in-entries:
+    specifiers: {}
+
+  playground/optimize-deps/dep-cjs-browser-field-bare:
     specifiers: {}
 
   playground/optimize-deps/dep-cjs-compiled-from-cjs:
@@ -9368,6 +9373,12 @@ packages:
     resolution: {directory: playground/optimize-deps/added-in-entries, type: directory}
     name: added-in-entries
     version: 1.0.0
+    dev: false
+
+  file:playground/optimize-deps/dep-cjs-browser-field-bare:
+    resolution: {directory: playground/optimize-deps/dep-cjs-browser-field-bare, type: directory}
+    name: dep-cjs-browser-field-bare
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-cjs-compiled-from-cjs:


### PR DESCRIPTION
Hi @sapphi-red 

I have performed a rebase of your [fix/optimizer-browser-field-bare-import branch](https://github.com/sapphi-red/vite/tree/fix/optimizer-browser-field-bare-import) on top of [main branch](https://github.com/sapphi-red/vite)

Comparing to the previous merge https://github.com/vitejs/vite/pull/8709 , the tests for macOS are passing now https://github.com/smeng9/vite/actions/runs/3004484619 .

Thanks for your time and can you help on getting this reviewed and close https://github.com/vitejs/vite/issues/7576 ?