### PR TITLE
docs: add lazy compilation details to bundled dev mode section

### DIFF
--- a/docs/blog/announcing-vite8-1.md
+++ b/docs/blog/announcing-vite8-1.md
@@ -67,6 +67,14 @@ Bundled Dev Mode would allow serving bundled files not only in production but al
 
 :::
 
+::: details How does it stay fast? Lazy compilation
+
+A naive bundled dev server would have to bundle the entire application before it can serve the first request, reintroducing exactly the slow startup that Vite's unbundled approach was designed to avoid.
+
+Bundled dev mode avoids this with **lazy compilation**. On startup, Vite does not bundle the whole app. Instead, modules are compiled on demand as the browser requests them, so only the code needed for the page you are actually looking at gets bundled. This keeps Vite's original on-demand philosophy intact while still serving bundled output, so cold start stays fast no matter how large the application grows.
+
+:::
+
 Currently, it focuses on the browser side and the basic plugins and the main features. If you are using a third party plugin, it may not work with this mode. If you are using a minor feature, it may not work as well. We are working on expanding the support and preparing a document that clarifies the changes that may be needed on the plugin side. See [the design document](https://example.com) for more details about the roadmap.
 
 // TODO: add link to the design document


### PR DESCRIPTION
Per our chat: lazy compilation is a fundamental part of bundled dev mode but wasn't covered in the 8.1 post yet. This adds a `::: details How does it stay fast? Lazy compilation` block to the **Experimental Bundled Dev Mode** section, right after the existing `Why bundled dev mode?` block.

It explains that bundled dev mode doesn't bundle the whole app up front — modules are compiled on demand as the browser requests them (`experimental.devMode.lazy: true` in Rolldown's dev engine, served via the `/@vite/lazy` endpoint) — which is what keeps cold start fast regardless of app size.

Feel free to tweak the wording or fold it in however reads best. Targeting your `docs/81-post` branch so it rides along with #22704.

🤖 Generated with [Claude Code](https://claude.com/claude-code)